### PR TITLE
Retract versions 1.0.0 and 1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/diogorodriguesc/lutetium-go
 
 go 1.23
+
+retract [v1.0.0, v1.0.1]


### PR DESCRIPTION
## Description 

The goal of this change request is to retract versions: `v1.0.0` and `v1.0.1`, so that the versions `0.x.x` are the ones selected on new installations. 